### PR TITLE
Ensure that the Multi-Use token is unique

### DIFF
--- a/src/main/java/org/broadleafcommerce/payment/service/gateway/SamplePaymentGatewayCustomerServiceImpl.java
+++ b/src/main/java/org/broadleafcommerce/payment/service/gateway/SamplePaymentGatewayCustomerServiceImpl.java
@@ -31,6 +31,8 @@ import org.broadleafcommerce.vendor.sample.service.payment.SamplePaymentGatewayT
 import org.springframework.stereotype.Service;
 import org.springframework.util.Assert;
 
+import java.util.Random;
+
 /**
  * @author Chris Kittrell (ckittrell)
  */
@@ -118,6 +120,9 @@ public class SamplePaymentGatewayCustomerServiceImpl extends AbstractPaymentGate
     }
 
     protected void parsePaymentToken(PaymentResponseDTO responseDTO) {
-        responseDTO.paymentToken("SAMPLE_PAYMENT_GATEWAY_MULTI_USE_TOKEN");
+        Random rnd = new Random();
+        int randomNumber = 100000 + rnd.nextInt(90000000);
+
+        responseDTO.paymentToken("SAMPLE_PAYMENT_GATEWAY_MULTI_USE_TOKEN_" + randomNumber);
     }
 }


### PR DESCRIPTION
BroadleafCommerce/QA#2934 

- Ensure that the multi-use paymentToken is unique so that multiple CustomerPayments will not have the same token