### PR TITLE
Rebaseline across library upgrades - Spring 5, Spring Boot 2, Hibernate 5, JDK 8

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.broadleafcommerce</groupId>
         <artifactId>broadleaf-module-parent</artifactId>
-        <version>1.0.14-GA</version>
+        <version>3.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>broadleaf-sample-payment-gateway</artifactId>
@@ -13,7 +13,7 @@
     <version>3.0.0-SNAPSHOT</version>
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <blc.version>5.1.0-GA</blc.version>
+        <blc.version>6.0.0-SNAPSHOT</blc.version>
         <project.uri>${user.dir}</project.uri>
     </properties>
     <scm>


### PR DESCRIPTION
First major feature within Broadleaf 6.0 as a baselining effort across our core libraries. This generally targets the Spring Boot 2.0 dependency line which includes:

- Hibernate 5.2.17
- Spring 5.0.6
- Spring Security 5.0.5
- Spring Boot 2.0.2
- Jackson 2.9.5

In regards to Java versions, this rebaselines Broadleaf on JDK 8 and 6.0 will be the first release compatible with JDK 9.

Related to https://github.com/BroadleafCommerce/BroadleafCommerce/pull/1887