### PR TITLE
Updated delimiter for the Credit Card data

### DIFF
--- a/src/main/java/org/broadleafcommerce/payment/service/gateway/SamplePaymentGatewayTransactionServiceImpl.java
+++ b/src/main/java/org/broadleafcommerce/payment/service/gateway/SamplePaymentGatewayTransactionServiceImpl.java
@@ -234,7 +234,7 @@ public class SamplePaymentGatewayTransactionServiceImpl extends AbstractPaymentG
     protected void setupNoncePaymentRequest(PaymentRequestDTO requestDTO) {
         String nonce = (String) requestDTO.getAdditionalFields().get(SamplePaymentGatewayConstants.PAYMENT_METHOD_NONCE);
         if (nonce != null) {
-            String[] fields = nonce.split("\\|");
+            String[] fields = nonce.split("#");
 
             String lastFour = (fields[0] == null) ? null : fields[0].substring(fields[0].length() - 4);
 


### PR DESCRIPTION
Changed delimiter regards the ESAPI pattern

A Brief Overview
The delimiter "|" is not supported by ESAPI pattern

Link to QA issue
BroadleafCommerce/QA#4399